### PR TITLE
Change icon for Resource Manager

### DIFF
--- a/codex-resources/package.json
+++ b/codex-resources/package.json
@@ -28,7 +28,7 @@
         {
           "id": "codex-resource-explorer",
           "title": "Codex Resource Explorer",
-          "icon": "$(open-editors-view-icon)"
+          "icon": "$(cloud-download)",
         }
       ]
     },
@@ -46,7 +46,7 @@
           "name": "All Resources",
           "type": "webview",
           "contextualTitle": "Scribe Resources",
-          "visibility": "collapsed"
+          "visibility": "visible"
         }
       ]
     }


### PR DESCRIPTION
There are a lot of activity bar menus that have the open book icon, and this cloud-download icon makes more sense IMO and helps differentiate the view from other views.